### PR TITLE
don't use short open tags

### DIFF
--- a/src/Dashboard/DashboardApplication.php
+++ b/src/Dashboard/DashboardApplication.php
@@ -40,7 +40,7 @@ final class DashboardApplication
             ?>
             </tbody>
         </table>
-        <?
+        <?php
 
         include __DIR__ . '/../Common/footer.html';
     }


### PR DESCRIPTION
To avoid issues the demo code should not use short open tags, the use of
short open tags has to be enabled manually in php.ini and is no longer
on by default.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>