### PR TITLE
[Feature] Add PhpStorm meta information for DB layer to improve code completion

### DIFF
--- a/src/Common/Persistence/.phpstorm.meta.php
+++ b/src/Common/Persistence/.phpstorm.meta.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPSTORM_META;
+
+/**
+ * This set of overrides simplifies a lot IDE autocompletion in the PhpStorm
+ */
+override(\Common\Persistence\Database::retrieve(), type(0));
+override(\Common\Persistence\Database::findOne(), type(0));
+override(\Common\Persistence\Database::retrieveAll(), map(['' => '@[]']));
+override(\Common\Persistence\Database::find(), map(['' => '@[]']));

--- a/src/Purchase/PurchaseApplication.php
+++ b/src/Purchase/PurchaseApplication.php
@@ -78,9 +78,7 @@ final class PurchaseApplication
     public function receiveGoodsController(): void
     {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            /** @var PurchaseOrder $purchaseOrder */
             $purchaseOrder = Database::retrieve(PurchaseOrder::class, $_POST['purchaseOrderId']);
-
             $purchaseOrder->markAsReceived();
 
             FlashMessage::add(FlashMessage::SUCCESS, 'Marked purchase order as received: ' . $_POST['purchaseOrderId']);

--- a/src/Sales/SalesApplication.php
+++ b/src/Sales/SalesApplication.php
@@ -78,7 +78,6 @@ final class SalesApplication
     public function deliverSalesOrderController(): void
     {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            /** @var SalesOrder $salesOrder */
             $salesOrder = Database::retrieve(SalesOrder::class, $_POST['salesOrderId']);
 
             // TODO make this judgement based on actual stock levels (assignment 05)

--- a/src/Stock/StockApplication.php
+++ b/src/Stock/StockApplication.php
@@ -47,7 +47,6 @@ final class StockApplication
      */
     public function makeStockReservationController(): void
     {
-        /** @var Balance $balance */
         $balance = Database::retrieve(Balance::class, $_POST['productId']);
 
         $reservationWasAccepted = $balance->makeReservation($_POST['reservationId'], (int)$_POST['quantity']);


### PR DESCRIPTION
This PR adds PhpStorm meta to avoid manual adding of types for each entity during workshop.