### PR TITLE
[Fix] Always bind to exact 127.0.0.1 localhost in Docker

### DIFF
--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -5,7 +5,7 @@ services:
         image: traefik:1.3-alpine
         command: --docker
         ports:
-            - "80:80"
+            - "127.0.0.1:80:80"
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
         networks:


### PR DESCRIPTION
We ensure that ipv6 or other interfaces won't be used by Docker, resolves #36 